### PR TITLE
Prevent looping activated plugins needlessly

### DIFF
--- a/plugin-name/includes/class.extension-activation.php
+++ b/plugin-name/includes/class.extension-activation.php
@@ -51,6 +51,7 @@ class EDD_Extension_Activation {
         foreach( $plugins as $plugin_path => $plugin ) {
             if( $plugin['Name'] == 'Easy Digital Downloads' ) {
                 $this->has_edd = true;
+                break;
             }
         }
     }


### PR DESCRIPTION
Prevent looping through activated plugins needlessly once EDD is found.
